### PR TITLE
Coq 8.19

### DIFF
--- a/coq/DeriveShow.v
+++ b/coq/DeriveShow.v
@@ -14,9 +14,13 @@ Module Internals.
 
   Ltac2 Type exn ::= [ NotAConstructor (constr) ].
 
+
+  (* rStrength is of type strength which is defined as:
+  Ltac2 Type strength := [ Norm | Head ].*)
+
   Ltac2 eval_simpl c :=
     Std.eval_simpl {
-        Std.rStrength := Norm;
+        Std.rStrength := Std.Norm;       
         Std.rBeta := true;
         Std.rMatch := true;
         Std.rFix := true;

--- a/coq/DeriveShow.v
+++ b/coq/DeriveShow.v
@@ -16,6 +16,7 @@ Module Internals.
 
   Ltac2 eval_simpl c :=
     Std.eval_simpl {
+        Std.rStrength := Norm;
         Std.rBeta := true;
         Std.rMatch := true;
         Std.rFix := true;

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1719604435,
-        "narHash": "sha256-v1wmHjL0WouIbNCVKoNMh6aYHlV0/gjqiKRJmbmkqpg=",
+        "lastModified": 1722040633,
+        "narHash": "sha256-d7/emJX5BmM6dpGBRR66gSwywHQT8K2aoweG2R2/74U=",
         "owner": "fluidattacks",
         "repo": "makes",
-        "rev": "78ffa66b104cdf5ce089f13596c43da588c5ed70",
+        "rev": "9b48d0e155d7fb08fc4e8318380e7a0cf359a202",
         "type": "github"
       },
       "original": {
@@ -54,23 +54,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721821769,
-        "narHash": "sha256-PhmkdTJs2SfqKzSyDB74rDKp1MH4mGk0pG/+WqrnGEw=",
+        "lastModified": 1734529975,
+        "narHash": "sha256-ze3IJksru9dN0keqUxY0WNf8xrwfs8Ty/z9v/keyBbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0907b75146a0ccc1ec0d6c3db287ec287588ef6",
+        "rev": "72d11d40b9878a67c38f003c240c2d2e1811e72a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,8 @@
         devShells.default = self'.checks.koika;
 
         packages = {
-          default = self'.packages.coq8_18-koika;
-          coq8_18-koika = pkgs.coqPackages_8_18.koika;
+          default = self'.packages.coq8_19-koika;
+          coq8_19-koika = pkgs.coqPackages_8_19.koika;
           coqDev-koika = pkgs.coqPackages_koika.koika;
         };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -6,7 +6,7 @@ final: prev: let
     });
 in
   (prev.lib.mapAttrs injectKoika {
-    inherit (final) coqPackages_8_14 coqPackages_8_18;
+    inherit (final) coqPackages_8_14 coqPackages_8_19;
   })
   // {
     coqPackages_koika = prev.coqPackages_8_14.overrideScope (self: super: {


### PR DESCRIPTION
This PR includes changes to upgrade to Coq 8.19, to solve the namespace issues happening with Derive in Equations